### PR TITLE
Add welcome banner next to collapsed menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,64 @@
     </aside>
 
     <main class="content" role="main">
-        <div class="placeholder"></div>
+        <section class="welcome-banner" aria-labelledby="welcome-banner-title">
+            <header class="welcome-banner__header">
+                <h1 class="welcome-banner__title" id="welcome-banner-title">Witamy w TALMEX</h1>
+            </header>
+            <div class="welcome-banner__body">
+                <p class="welcome-banner__intro">Od ponad 30 lat poszerzamy nasze kompetencje w zakresie:</p>
+                <div class="welcome-banner__details">
+                    <div class="welcome-banner__icon-stack" aria-hidden="true">
+                        <span class="welcome-banner__icon">
+                            <svg viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+                                <circle cx="32" cy="32" r="27" fill="#fff" stroke="#111" stroke-width="3" />
+                                <circle cx="32" cy="32" r="17" fill="none" stroke="#111" stroke-width="3" />
+                                <path d="M23 32h18M32 23v18" stroke="#199848" stroke-width="4" stroke-linecap="round" />
+                                <circle cx="20" cy="32" r="3.5" fill="#199848" stroke="#111" stroke-width="2" />
+                                <circle cx="44" cy="32" r="3.5" fill="#199848" stroke="#111" stroke-width="2" />
+                                <circle cx="32" cy="20" r="3.5" fill="#199848" stroke="#111" stroke-width="2" />
+                                <circle cx="32" cy="44" r="3.5" fill="#199848" stroke="#111" stroke-width="2" />
+                            </svg>
+                        </span>
+                        <span class="welcome-banner__icon">
+                            <svg viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+                                <circle cx="32" cy="32" r="27" fill="#fff" stroke="#111" stroke-width="3" />
+                                <path d="M32 12c9 11 13 18 13 25a13 13 0 1 1-26 0c0-7 4-14 13-25z" fill="#199848" stroke="#111" stroke-width="3" stroke-linejoin="round" />
+                                <path d="M17 25a20 20 0 0 0 0 14M47 25a20 20 0 0 1 0 14" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round" />
+                                <path d="M15 32h-6m46 0h-6" stroke="#111" stroke-width="3" stroke-linecap="round" />
+                                <path d="M14 40l-4 4m0-16l4 4M50 24l4-4m0 16l-4-4" stroke="#199848" stroke-width="3" stroke-linecap="round" />
+                            </svg>
+                        </span>
+                        <span class="welcome-banner__icon">
+                            <svg viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+                                <circle cx="32" cy="32" r="27" fill="#fff" stroke="#111" stroke-width="3" />
+                                <path d="M20 38c0-8 5-15 12-18l7 18c-2 5-7 8-12 8a12 12 0 0 1-7-8z" fill="#f0f6f3" stroke="#111" stroke-width="3" stroke-linejoin="round" />
+                                <path d="M24 28c7 0 12 5 12 12" fill="none" stroke="#199848" stroke-width="3" stroke-linecap="round" />
+                                <circle cx="42" cy="42" r="7" fill="#fff" stroke="#111" stroke-width="3" />
+                                <path d="M42 38a4 4 0 1 1-4 4" fill="#199848" stroke="#111" stroke-width="2" />
+                                <path d="M47 47l6 6" stroke="#111" stroke-width="3" stroke-linecap="round" />
+                                <path d="M24 18h16l-2 10H26l-2-10z" fill="#199848" stroke="#111" stroke-width="3" stroke-linejoin="round" />
+                            </svg>
+                        </span>
+                        <span class="welcome-banner__icon">
+                            <svg viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+                                <circle cx="32" cy="32" r="27" fill="#fff" stroke="#111" stroke-width="3" />
+                                <path d="M25 20c4 5 6 9 6 13a9 9 0 1 1-18 0c0-4 2-8 6-13z" fill="#111" stroke="#111" stroke-width="2" stroke-linejoin="round" />
+                                <path d="M39 20c4 5 6 9 6 13a9 9 0 1 1-18 0c0-4 2-8 6-13z" fill="#199848" stroke="#111" stroke-width="3" stroke-linejoin="round" />
+                                <path d="M26 32h12" stroke="#fff" stroke-width="3" stroke-linecap="round" />
+                                <path d="M18 26l-5-5m5 21l-5 5m33-21l5-5m-5 21l5 5" stroke="#199848" stroke-width="3" stroke-linecap="round" />
+                            </svg>
+                        </span>
+                    </div>
+                    <ul class="welcome-banner__list">
+                        <li class="welcome-banner__item">Przemysłowe instalacje technologiczne</li>
+                        <li class="welcome-banner__item">Odzysk i uzdatnianie wody</li>
+                        <li class="welcome-banner__item">Oczyszczanie ścieków</li>
+                        <li class="welcome-banner__item">Badania pilotażowe i dobór technologii</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
     </main>
 
     <script>// ====== Selektory ======
@@ -146,6 +203,7 @@
             sideNav.style.width = px + 'px';
             content.style.marginLeft = px + 'px';
             navEdge.style.left = (px - 1) + 'px'; // linia 2px
+            document.documentElement.style.setProperty('--nav-current-width', px + 'px');
         }
 
         // pozycja + szerokość zielonego panelu (etap 2), oraz pionowe wyrównanie

--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,7 @@ body {
     --brand: #199848;
     --sygnet-size-closed: 67px;
     --pale-green: #eaf7f0;
+    --nav-current-width: var(--nav-w-closed);
 }
 
 /* ====== Stabilna prawa linia (animuje left razem z panelem) ====== */
@@ -269,19 +270,146 @@ body {
 
 /* ====== Treść ====== */
 .content {
-    margin-left: var(--nav-w-closed); /* start 5vw; dalej JS ustawia piksele */
+    margin-left: var(--nav-current-width, var(--nav-w-closed));
     min-height: 100vh;
-    display: grid;
-    place-items: center;
+    padding: clamp(48px, 8vw, 96px) clamp(24px, 6vw, 72px);
+    padding-left: calc(clamp(24px, 6vw, 72px) + 40px);
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: clamp(24px, 6vw, 72px);
     transition: margin-left .35s cubic-bezier(.22,.61,.36,1);
 }
 
-.placeholder {
-    width: min(70ch, 70%);
-    height: 40vh;
-    border: 1px dashed #ddd;
-    border-radius: 12px;
-    opacity: .15;
+.welcome-banner {
+    width: min(440px, 100%);
+    background: #fff;
+    border-radius: 16px;
+    box-shadow: 0 30px 70px rgba(17, 17, 17, 0.12);
+    overflow: hidden;
+    font-family: "Biryani", system-ui, sans-serif;
+    border: 1px solid rgba(25, 152, 72, .1);
+}
+
+.welcome-banner__header {
+    background: var(--brand);
+    color: #fff;
+    padding: 22px 28px;
+}
+
+.welcome-banner__title {
+    margin: 0;
+    font-size: clamp(20px, 2vw + 12px, 28px);
+    letter-spacing: .02em;
+    font-weight: 600;
+}
+
+.welcome-banner__body {
+    padding: 26px 28px 30px;
+    color: #1f1f1f;
+}
+
+.welcome-banner__intro {
+    margin: 0 0 22px;
+    font-size: 16px;
+    line-height: 1.6;
+    max-width: 26ch;
+}
+
+.welcome-banner__details {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 18px 28px;
+}
+
+.welcome-banner__icon-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    align-items: center;
+    position: relative;
+    padding-right: 20px;
+}
+
+.welcome-banner__icon-stack::after {
+    content: "";
+    position: absolute;
+    top: 6px;
+    bottom: 6px;
+    right: 0;
+    width: 2px;
+    background: rgba(17, 17, 17, .18);
+}
+
+.welcome-banner__icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #fff;
+    box-shadow: 0 8px 18px rgba(17, 17, 17, 0.12);
+}
+
+.welcome-banner__icon svg {
+    width: 54px;
+    height: 54px;
+    display: block;
+}
+
+.welcome-banner__list {
+    list-style: none;
+    margin: 0;
+    padding: 6px 0;
+    display: grid;
+    gap: 18px;
+    font-size: 17px;
+    line-height: 1.4;
+}
+
+.welcome-banner__item {
+    position: relative;
+    padding-left: 4px;
+}
+
+@media (max-width: 720px) {
+    .content {
+        padding-left: clamp(24px, 6vw, 40px);
+    }
+
+    .welcome-banner {
+        width: 100%;
+    }
+
+    .welcome-banner__details {
+        grid-template-columns: 1fr;
+    }
+
+    .welcome-banner__icon-stack {
+        flex-direction: row;
+        justify-content: space-between;
+        padding-right: 0;
+    }
+
+    .welcome-banner__icon-stack::after {
+        display: none;
+    }
+
+    .welcome-banner__icon {
+        width: 56px;
+        height: 56px;
+        box-shadow: 0 6px 14px rgba(17, 17, 17, 0.12);
+    }
+
+    .welcome-banner__icon svg {
+        width: 48px;
+        height: 48px;
+    }
+
+    .welcome-banner__list {
+        gap: 12px;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- replace the placeholder content area with a CSS-based welcome banner styled with the Biryani typeface
- draw four themed SVG icons and lay out the text to mirror the provided banner approximately 40px from the menu
- expose the navigation width as a CSS variable so the banner keeps consistent spacing as the menu animates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca964de1dc8325b54495c62fc57130