### PR TITLE
Keep main content offset tied to collapsed navigation width

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,6 @@
 
     <script>// ====== Selektory ======
         const sideNav = document.querySelector('.side-nav');
-        const content = document.querySelector('.content');
         const navEdge = document.querySelector('.nav-edge');
         const toggleBtn = document.querySelector('.menu-toggle');
         const labelsRail = document.querySelector('.labels-rail');
@@ -203,9 +202,7 @@
         function setPanelRight(px) {
             // docelowe piksele dla panelu, treści i prawej linii (animują się spójnie)
             sideNav.style.width = px + 'px';
-            content.style.marginLeft = px + 'px';
             navEdge.style.left = (px - 1) + 'px'; // linia 2px
-            document.documentElement.style.setProperty('--nav-current-width', px + 'px');
         }
 
         // pozycja + szerokość zielonego panelu (etap 2), oraz pionowe wyrównanie

--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,6 @@ body {
     --brand: #199848;
     --sygnet-size-closed: 67px;
     --pale-green: #eaf7f0;
-    --nav-current-width: var(--nav-w-closed);
 }
 
 /* ====== Stabilna prawa linia (animuje left razem z panelem) ====== */
@@ -383,7 +382,7 @@ body {
 
 /* ====== Treść ====== */
 .content {
-    margin-left: var(--nav-current-width, var(--nav-w-closed));
+    margin-left: calc(var(--nav-w-closed) + 40px);
     min-height: 100vh;
     padding: clamp(48px, 8vw, 96px) clamp(24px, 6vw, 72px);
     padding-left: calc(clamp(24px, 6vw, 72px) + 40px);


### PR DESCRIPTION
## Summary
- make the main content margin depend only on the collapsed rail width so the banner stays aligned when the drawer opens
- stop writing the panel width into a global CSS variable and restrict the script updates to the panel and nav edge positioning

## Testing
- python3 -m http.server 8000 (with Playwright automation to toggle the menu)


------
https://chatgpt.com/codex/tasks/task_e_68caaaa6eca883258ce6e4edf95b9ac2